### PR TITLE
Fixed position for fish-eye pic

### DIFF
--- a/css/frog.css
+++ b/css/frog.css
@@ -65,21 +65,30 @@ img.align {
 
 .content-right {
     flex: 1;
+    margin-top: -80px;
+}
+
+.content-right h2 {
+    padding-bottom: 30px;
 }
 
 .eye-view img {
     border-radius: 50%;
     object-fit: cover;
-    max-width: 200px;
-    max-height: 200px;
+    max-width: 350px;
+    max-height: 800px;
+    margin-left: -180px;
+    margin-top: -150px;
 }
 
 .fish-eye img {
     border-radius: 50%;
     object-fit: cover;
-    max-width: 200px;
-    max-height: 200px;
-    margin: -50px;
+    max-width: 300px;
+    max-height: 400px;
+    margin-right: 50px;
+    margin-top: 100px;
+    margin-left: -100px;
 }
 
 .amphibian h2 {


### PR DESCRIPTION
Fixed the positioning of the pictures and paragraph, allowing there to be sufficient spacing that highlighted the content to be focused on. Still not reactive. Will address the reactivity for all pages at a later time. 